### PR TITLE
Fix MODULE_LICENSE for v2r modules

### DIFF
--- a/drivers/v2r/v2r_adc.c
+++ b/drivers/v2r/v2r_adc.c
@@ -403,4 +403,4 @@ module_init(adc_init_module);
 module_exit(adc_exit_module);
 MODULE_DESCRIPTION("Virt2real ADC driver module version 1.1");
 MODULE_AUTHOR("Shlomo Kut,,, (shl...@infodraw.com). Features added by Gol.");
-MODULE_LICENSE("GPL2");
+MODULE_LICENSE("GPL v2");

--- a/drivers/v2r/v2r_extpwm.c
+++ b/drivers/v2r/v2r_extpwm.c
@@ -544,7 +544,7 @@ static void __exit extpwm_exit(void)
 
 MODULE_AUTHOR("Gol gol@g0l.ru");
 MODULE_DESCRIPTION("External PWM driver v0.1");
-MODULE_LICENSE("GPL2");
+MODULE_LICENSE("GPL v2");
 
 module_init(extpwm_init);
 module_exit(extpwm_exit);

--- a/drivers/v2r/v2r_gpio.c
+++ b/drivers/v2r/v2r_gpio.c
@@ -1453,4 +1453,4 @@ module_exit(gpio_exit_module);
 MODULE_DESCRIPTION("Virt2real GPIO Driver version 0.3");
 MODULE_AUTHOR("Alexandr Shadrin");
 MODULE_AUTHOR("Gol (gol@g0l.ru)");
-MODULE_LICENSE("GPL2");
+MODULE_LICENSE("GPL v2");

--- a/drivers/v2r/v2r_pins.c
+++ b/drivers/v2r/v2r_pins.c
@@ -1595,4 +1595,4 @@ module_exit(pins_exit_module);
 MODULE_DESCRIPTION("Virt2real CON driver module version 0.3");
 MODULE_AUTHOR("Alexandr Shadrin");
 MODULE_AUTHOR("Gol (gol@g0l.ru)");
-MODULE_LICENSE("GPL2");
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
MODULE_LICENSE expects 'GPL v2' not GPL2

V2R stuff are failed to build as modules with MODULE_LICENSE("GPL2")
